### PR TITLE
content type header charset param fix

### DIFF
--- a/exquery-common/src/main/java/org/exquery/http/ContentTypeHeader.java
+++ b/exquery-common/src/main/java/org/exquery/http/ContentTypeHeader.java
@@ -41,8 +41,12 @@ public class ContentTypeHeader {
     private final static String CHARSET_SEPARATOR = ";";
     private final static String CHARSET_KEY = "charset";
     private final static String CHARSET_KEY_VALUE_SEPARATOR = "=";
-
-    public final static String contentType_regExp =  "(" + InternetMediaType.mediaType_regExp + ")" + "(" + CHARSET_SEPARATOR + "\\s*" + CHARSET_KEY + CHARSET_KEY_VALUE_SEPARATOR + "(.+))?";
+    
+    // @see <a herf="https://tools.ietf.org/html/rfc2978#section-2.3">Section 2.3 of [RFC2978]</a>
+    public final static String charset_regExp = "[a-zA-Z0-9!#\\$%&'\\+\\-\\^_`\\{\\}~]+";
+    public final static String charsetParam_regExp = CHARSET_KEY + CHARSET_KEY_VALUE_SEPARATOR + "\"?" + "(" + charset_regExp + ")" + "\"?";
+    
+    public final static String contentType_regExp = "^(" + InternetMediaType.mediaType_regExp + ")" + "(.*" + CHARSET_SEPARATOR + "\\s*" + charsetParam_regExp + ")?.*";
     public final static Pattern ptnContentType = Pattern.compile(contentType_regExp);
 
     private final static Pattern ptnInternetMediaType = Pattern.compile(InternetMediaType.mediaType_regExp);

--- a/exquery-common/src/test/java/org/exquery/http/ContentTypeHeaderTest.java
+++ b/exquery-common/src/test/java/org/exquery/http/ContentTypeHeaderTest.java
@@ -69,6 +69,36 @@ public class ContentTypeHeaderTest {
         assertEquals("UTF-8", header.getCharset());
     }
     
+    @Test
+    public void extracts_internetMediaType_and_charset3() {
+        final String headerValue = APPLICATION_XML.getMediaType() + "; charset=\"UTF-8\"";
+        
+        final ContentTypeHeader header = new ContentTypeHeader(headerValue);
+        
+        assertEquals(APPLICATION_XML.getMediaType(), header.getInternetMediaType());
+        assertEquals("UTF-8", header.getCharset());
+    }
+    
+    @Test
+    public void extracts_internetMediaType_with_extendingParameter_and_nullCharset() {
+        final String headerValue = APPLICATION_XML.getMediaType() + "; parameter=some_value";
+        
+        final ContentTypeHeader header = new ContentTypeHeader(headerValue);
+        
+        assertEquals(APPLICATION_XML.getMediaType(), header.getInternetMediaType());
+        assertNull(header.getCharset());
+    }
+    
+    @Test
+    public void extracts_internetMediaType_with_additionalParameter_and_charset() {
+        final String headerValue = APPLICATION_XML.getMediaType() + "; parameter=some_value; charset=UTF-8";
+        
+        final ContentTypeHeader header = new ContentTypeHeader(headerValue);
+        
+        assertEquals(APPLICATION_XML.getMediaType(), header.getInternetMediaType());
+        assertEquals("UTF-8", header.getCharset());
+    }
+    
     @Test(expected = IllegalArgumentException.class)
     public void rejects_wildcard_internetMediaType() {
         final ContentTypeHeader header = new ContentTypeHeader(ANY.getMediaType());


### PR DESCRIPTION
In content type header a charset parameter is optional and its allowed to define another optional parameters between content type and charset. Exquery throws an exception in this case.
This commit fixes this issue