### PR TITLE
Prevent NPE when no path info is provided by servlet

### DIFF
--- a/exquery-restxq/src/main/java/org/exquery/restxq/impl/annotation/PathAnnotationImpl.java
+++ b/exquery-restxq/src/main/java/org/exquery/restxq/impl/annotation/PathAnnotationImpl.java
@@ -26,12 +26,6 @@
  */
 package org.exquery.restxq.impl.annotation;
 
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 import org.exquery.http.URI;
 import org.exquery.restxq.RestXqErrorCodes;
 import org.exquery.restxq.RestXqErrorCodes.RestXqErrorCode;
@@ -40,6 +34,13 @@ import org.exquery.restxq.annotation.RestAnnotationException;
 import org.exquery.xquery.Cardinality;
 import org.exquery.xquery.Literal;
 import org.exquery.xquery.Type;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 /**
  * Implementation of RESTXQ Path Annotation
@@ -84,6 +85,11 @@ public class PathAnnotationImpl extends AbstractRestAnnotation implements PathAn
 
     @Override
     public boolean matchesPath(final String path) {
+
+        if (path == null) {
+            return false;
+        }
+
         final Matcher m = getPathInformation().getPathMatcher(path);
         return m.matches();
     }
@@ -91,7 +97,12 @@ public class PathAnnotationImpl extends AbstractRestAnnotation implements PathAn
     @Override
     public Map<String, String> extractPathParameters(final String uriPath) {
         
-        final Map<String, String> pathParamNameAndValues = new HashMap<String, String>();        
+        final Map<String, String> pathParamNameAndValues = new HashMap<String, String>();
+
+        if (uriPath == null) {
+            return pathParamNameAndValues;
+        }
+
         final Matcher m = getPathInformation().getPathMatcher(uriPath);        
 
         if(m.matches()) {

--- a/exquery-restxq/src/test/java/org/exquery/restxq/impl/annotation/PathAnnotationImplTest.java
+++ b/exquery-restxq/src/test/java/org/exquery/restxq/impl/annotation/PathAnnotationImplTest.java
@@ -38,6 +38,7 @@ import org.exquery.xquery3.Annotation;
 import org.exquery.xquery3.FunctionSignature;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertFalse;
 
 import org.junit.Test;
 
@@ -468,6 +469,24 @@ public class PathAnnotationImplTest {
         final String requestPath = "/path1";
 
         assertTrue(pa.matchesPath(requestPath));
+        final Map<String, String> requestPathParams = pa.extractPathParameters(requestPath);
+        assertEquals(0, requestPathParams.size());
+    }
+
+    @Test
+    public void parse_nopath_zeroParams() throws RestAnnotationException {
+
+        final PathAnnotationImpl pa = new PathAnnotationImpl();
+        pa.setFunctionSignature(new NoArgsFunctionSignature());
+        pa.setLiterals(new Literal[]{
+                new StringLiteral("/path1")
+        });
+
+        pa.initialise();
+
+        final String requestPath = null;
+
+        assertFalse(pa.matchesPath(requestPath));
         final Map<String, String> requestPathParams = pa.extractPathParameters(requestPath);
         assertEquals(0, requestPathParams.size());
     }


### PR DESCRIPTION
Fixes #33  @adamretter 

# Test
Deploy new jar file into `exist/extensions/exquery/restxq/lib/exquery-restxq-1.0-SNAPSHOT.jar`, restart eXist-db and invoke `http://localhost:8080/exist/restxq/`.

# result

<img width="519" alt="image" src="https://user-images.githubusercontent.com/1700062/40678785-bd1e94a2-6381-11e8-8cbd-1c1747a7499b.png">
